### PR TITLE
Refactor home layout with video header and image hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,40 +15,45 @@
 
 
 
-  <header class="site-header">
-    <div class="header-bar">
-      <a class="header-logo" href="#inicio">VAPEZRT</a>
-      <nav class="header-nav" aria-label="Secciones principales">
-        <a href="#productos">Productos</a>
-        <a href="#contacto">Contacto</a>
-      </nav>
-      <a class="header-cta" href="https://wa.me/5493487652952" target="_blank" rel="noopener">Comprar ahora</a>
+  <header class="site-header" id="inicio">
+    <div class="header-top">
+      <div class="header-bar">
+        <a class="header-logo" href="#inicio">VAPEZRT</a>
+        <nav class="header-nav" aria-label="Secciones principales">
+          <a href="#productos">Productos</a>
+          <a href="#contacto">Contacto</a>
+        </nav>
+        <a class="header-cta" href="https://wa.me/5493487652952" target="_blank" rel="noopener">Comprar ahora</a>
+      </div>
+      <div class="header-announcement" aria-live="polite">
+        <div class="anuncio-carrusel">
+          <div class="mensaje" id="mensaje-rotativo">📱 Seguinos en Instagram @vapezrt_</div>
+        </div>
+      </div>
     </div>
-    <div class="header-announcement" aria-live="polite">
-      <div class="anuncio-carrusel">
-        <div class="mensaje" id="mensaje-rotativo">📱 Seguinos en Instagram @vapezrt_</div>
+    <div class="header-visual">
+      <video class="header-video" autoplay muted loop playsinline preload="metadata" poster="/assets/2023_1120_Ignite_Lifestyle_MikeKirschbaum_016_1_1000x.webp">
+        <source src="/assets/Ink-35508-1.mp4" type="video/mp4" />
+      </video>
+      <div class="section-container header-visual-content">
+        <div class="header-copy">
+          <span class="hero-badge">Experiencias premium</span>
+          <h1>Explorá nuestros sabores</h1>
+          <p>Los mejores pods y desechables, curados para que encuentres tu vapor ideal al instante.</p>
+        </div>
       </div>
     </div>
   </header>
 
-<section class="hero" id="inicio">
-  <video class="hero-video" autoplay muted loop playsinline>
-    <source src="/assets/Ink-35508-1.mp4" type="video/mp4" />
-  </video>
-  <div class="section-container hero-layout">
-    <div class="hero-card">
-      <div class="hero-contenido">
-        <span class="hero-badge">Experiencias premium</span>
-        <h1>Explorá nuestros sabores</h1>
-        <p>Los mejores pods y desechables, curados para que encuentres tu vapor ideal al instante.</p>
-        <form class="hero-busqueda" role="search">
-          <label class="sr-only" for="buscador">Buscar productos</label>
-          <input type="search" id="buscador" name="buscador" placeholder="Buscar productos... 🔍" autocomplete="off" />
-        </form>
-      </div>
+<section class="hero" aria-labelledby="galeria-title">
+  <div class="section-container hero-gallery">
+    <div class="hero-gallery-main">
+      <img id="hero-imagen" src="/assets/2023_1120_Ignite_Lifestyle_MikeKirschbaum_016_1_1000x.webp" alt="Dispositivo vape color negro iluminado" />
     </div>
-    <div class="hero-visual" aria-hidden="true">
-      <img id="hero-imagen" src="/assets/2023_1120_Ignite_Lifestyle_MikeKirschbaum_016_1_1000x.webp" alt="Vaper destacado" />
+    <div class="hero-gallery-stack" aria-labelledby="galeria-title">
+      <h2 id="galeria-title" class="sr-only">Galería de sabores destacados</h2>
+      <img src="assets/Imagen de WhatsApp 2025-07-17 a las 22.23.09_bf985f76.webp.jpg" alt="Variedad de vapers sobre fondo azul" loading="lazy" />
+      <img src="/assets/Imagen de WhatsApp 2025-07-18 a las 01.27.53_af5c1526.jpg" alt="Detalle de pod con luces de neón" loading="lazy" />
     </div>
   </div>
 </section>
@@ -66,7 +71,27 @@
         <div class="beneficio">🎯 Productos 100% originales</div>
       </div>
     </div>
+  </div>
+</section>
 
+<section class="busqueda-section">
+  <div class="section-container">
+    <div class="hero-card">
+      <div class="hero-contenido">
+        <span class="hero-badge">Buscá tu próximo pod</span>
+        <h2>Encontrá tu sabor favorito</h2>
+        <p>Filtrá por marca, sabor o formato y descubrí qué vaper combina mejor con tu estilo.</p>
+        <form class="hero-busqueda" role="search">
+          <label class="sr-only" for="buscador">Buscar productos</label>
+          <input type="search" id="buscador" name="buscador" placeholder="Buscar productos... 🔍" autocomplete="off" />
+        </form>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="productos-grid-section">
+  <div class="section-container">
     <main id="productos" class="productos">
       <!-- Acá se insertan los productos -->
     </main>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -35,6 +35,34 @@ document.addEventListener("DOMContentLoaded", () => {
     }, 5000);
   }
 
+  const headerVideo = document.querySelector(".header-video");
+  if (headerVideo instanceof HTMLVideoElement) {
+    const motionQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+
+    const handleMotionPreference = () => {
+      if (motionQuery.matches) {
+        headerVideo.pause();
+        headerVideo.removeAttribute("autoplay");
+        headerVideo.currentTime = 0;
+        headerVideo.load();
+      } else {
+        headerVideo.setAttribute("autoplay", "autoplay");
+        const playPromise = headerVideo.play();
+        if (playPromise && typeof playPromise.then === "function") {
+          playPromise.catch(() => {});
+        }
+      }
+    };
+
+    handleMotionPreference();
+
+    if (typeof motionQuery.addEventListener === "function") {
+      motionQuery.addEventListener("change", handleMotionPreference);
+    } else if (typeof motionQuery.addListener === "function") {
+      motionQuery.addListener(handleMotionPreference);
+    }
+  }
+
   const cerrarModal = document.getElementById("cerrarModal");
   const cerrarSecundario = document.getElementById("modal-close-secondary");
   const modal = document.getElementById("modal");

--- a/styles.css
+++ b/styles.css
@@ -112,9 +112,16 @@ button {
 }
 
 .site-header {
+  position: relative;
+  background: var(--color-base);
+  color: var(--color-text);
+  overflow: hidden;
+}
+
+.header-top {
   position: sticky;
   top: 0;
-  z-index: 900;
+  z-index: 20;
   background: rgba(255, 255, 255, 0.9);
   backdrop-filter: blur(12px);
   border-bottom: 1px solid var(--color-border);
@@ -223,25 +230,26 @@ button {
   }
 }
 
-.hero {
+
+.header-visual {
   position: relative;
   isolation: isolate;
-  min-height: clamp(60vh, 68vh, 72vh);
+  min-height: 46vh;
   display: flex;
   align-items: center;
+  justify-content: center;
   padding: clamp(64px, 12vw, 96px) 0;
-  overflow: hidden;
 }
 
-.hero::before {
+.header-visual::before {
   content: "";
   position: absolute;
   inset: 0;
-  background: rgba(255, 255, 255, 0.7);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.82) 0%, rgba(255, 255, 255, 0.68) 100%);
   z-index: -1;
 }
 
-.hero-video {
+.header-video {
   position: absolute;
   inset: 0;
   width: 100%;
@@ -250,13 +258,85 @@ button {
   z-index: -2;
 }
 
-.hero-layout {
+.header-visual-content {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  display: flex;
+  justify-content: flex-start;
+}
+
+.header-copy {
+  max-width: 520px;
+  padding: clamp(24px, 5vw, 40px);
+  border-radius: var(--radius-surface);
+  border: 1px solid rgba(229, 231, 235, 0.8);
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: var(--shadow-elev-2);
+}
+
+.header-copy h1 {
+  font-size: clamp(2.4rem, 5vw, 3.4rem);
+  margin: 0 0 var(--space-16);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--color-text);
+}
+
+.header-copy p {
+  margin: 0;
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+}
+
+.hero {
+  background: var(--color-base);
+  padding: clamp(56px, 10vw, 88px) 0;
+}
+
+.hero-gallery {
   position: relative;
   display: grid;
-  align-items: center;
-  gap: clamp(24px, 6vw, 40px);
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: clamp(20px, 6vw, 40px);
+  align-items: stretch;
+  min-height: 54vh;
+}
+
+.hero-gallery-main,
+.hero-gallery-stack {
+  position: relative;
+  border-radius: var(--radius-surface);
+  overflow: hidden;
+}
+
+.hero-gallery-main {
+  box-shadow: var(--shadow-elev-2);
+  background: var(--color-muted);
+  min-height: 320px;
+}
+
+.hero-gallery-main img {
   width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.hero-gallery-stack {
+  display: grid;
+  gap: clamp(16px, 4vw, 24px);
+  grid-auto-rows: 1fr;
+  min-height: 320px;
+}
+
+.hero-gallery-stack img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: var(--radius-surface);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-elev-1);
+  background: var(--color-base);
+  aspect-ratio: 4 / 5;
 }
 
 .hero-card {
@@ -265,11 +345,13 @@ button {
   border: 1px solid var(--color-border);
   box-shadow: var(--shadow-elev-2);
   padding: clamp(24px, 5vw, 40px);
-  max-width: 520px;
+  max-width: 560px;
+  margin: 0 auto;
 }
 
-.hero-contenido h1 {
-  font-size: clamp(2.3rem, 5vw, 3.2rem);
+
+.hero-contenido h2 {
+  font-size: clamp(1.8rem, 4vw, 2.4rem);
   margin: 0 0 var(--space-16);
   font-weight: 600;
   letter-spacing: -0.01em;
@@ -278,7 +360,7 @@ button {
 
 .hero-contenido p {
   margin: 0 0 var(--space-24);
-  max-width: 40ch;
+  max-width: 48ch;
   color: var(--color-text-secondary);
 }
 
@@ -323,24 +405,19 @@ button {
   box-shadow: 0 0 0 4px rgba(17, 24, 39, 0.12);
 }
 
-.hero-visual {
-  justify-self: center;
-  width: min(420px, 100%);
-}
-
-.hero-visual img {
-  width: 100%;
-  aspect-ratio: 3 / 4;
-  object-fit: cover;
-  border-radius: var(--radius-surface);
-  border: 1px solid var(--color-border);
-  box-shadow: var(--shadow-elev-2);
-  background: #fff;
-}
-
 .productos-section {
   padding: clamp(64px, 12vw, 96px) 0;
   background: var(--color-base);
+}
+
+.busqueda-section {
+  background: var(--color-base);
+  padding: clamp(16px, 5vw, 32px) 0 clamp(56px, 10vw, 88px);
+}
+
+.productos-grid-section {
+  background: var(--color-base);
+  padding: clamp(16px, 5vw, 32px) 0 clamp(80px, 12vw, 120px);
 }
 
 .productos-intro {
@@ -689,18 +766,23 @@ button {
     display: none;
   }
 
-  .hero {
-    padding-top: 72px;
+  .hero-gallery {
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 
 @media (max-width: 768px) {
-  .hero-card {
-    margin: 0 auto;
+  .header-copy {
+    padding: clamp(24px, 8vw, 36px);
   }
 
-  .hero-visual {
-    width: min(320px, 100%);
+  .hero-gallery {
+    min-height: 52vh;
+  }
+
+  .hero-gallery-main,
+  .hero-gallery-stack {
+    min-height: 260px;
   }
 
   .productos-beneficios {
@@ -722,15 +804,22 @@ button {
     font-size: 0.9rem;
   }
 
-  .hero {
-    padding: 56px 0 64px;
-  }
-
-  .hero-contenido h1 {
-    font-size: clamp(2rem, 8vw, 2.4rem);
+  .header-copy h1 {
+    font-size: clamp(2rem, 8vw, 2.6rem);
   }
 
   .productos {
     grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (min-width: 768px) {
+  .header-visual {
+    min-height: 62vh;
+  }
+
+  .hero-gallery {
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+    min-height: 76vh;
   }
 }


### PR DESCRIPTION
## Summary
- move the autoplay background video into the header with a sticky navigation bar and motion preference handling
- introduce an image-based hero gallery beneath the header and reposition the search card below the product intro
- refresh home page spacing and containers to keep the light theme consistent across sections

## Testing
- No automated tests (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ddb030502c83279f857b79605fb33a