### PR TITLE
Move header background video behind content

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,11 @@
 
 
   <header class="site-header" id="inicio">
+    <div class="header-media" aria-hidden="true">
+      <video class="header-video" autoplay muted loop playsinline preload="metadata" poster="/assets/2023_1120_Ignite_Lifestyle_MikeKirschbaum_016_1_1000x.webp">
+        <source src="/assets/Ink-35508-1.mp4" type="video/mp4" />
+      </video>
+    </div>
     <div class="header-top">
       <div class="header-bar">
         <a class="header-logo" href="#inicio">VAPEZRT</a>
@@ -32,9 +37,6 @@
       </div>
     </div>
     <div class="header-visual">
-      <video class="header-video" autoplay muted loop playsinline preload="metadata" poster="/assets/2023_1120_Ignite_Lifestyle_MikeKirschbaum_016_1_1000x.webp">
-        <source src="/assets/Ink-35508-1.mp4" type="video/mp4" />
-      </video>
       <div class="section-container header-visual-content">
         <div class="header-copy">
           <span class="hero-badge">Experiencias premium</span>
@@ -45,18 +47,18 @@
     </div>
   </header>
 
-<section class="hero" aria-labelledby="galeria-title">
-  <div class="section-container hero-gallery">
-    <div class="hero-gallery-main">
-      <img id="hero-imagen" src="/assets/2023_1120_Ignite_Lifestyle_MikeKirschbaum_016_1_1000x.webp" alt="Dispositivo vape color negro iluminado" />
+  <section class="hero" aria-labelledby="galeria-title">
+    <div class="section-container hero-gallery">
+      <div class="hero-gallery-main">
+        <img id="hero-imagen" src="/assets/2023_1120_Ignite_Lifestyle_MikeKirschbaum_016_1_1000x.webp" alt="Dispositivo vape color negro iluminado" />
+      </div>
+      <div class="hero-gallery-stack" aria-labelledby="galeria-title">
+        <h2 id="galeria-title" class="sr-only">Galería de sabores destacados</h2>
+        <img src="assets/Imagen de WhatsApp 2025-07-17 a las 22.23.09_bf985f76.webp.jpg" alt="Variedad de vapers sobre fondo azul" loading="lazy" />
+        <img src="/assets/Imagen de WhatsApp 2025-07-18 a las 01.27.53_af5c1526.jpg" alt="Detalle de pod con luces de neón" loading="lazy" />
+      </div>
     </div>
-    <div class="hero-gallery-stack" aria-labelledby="galeria-title">
-      <h2 id="galeria-title" class="sr-only">Galería de sabores destacados</h2>
-      <img src="assets/Imagen de WhatsApp 2025-07-17 a las 22.23.09_bf985f76.webp.jpg" alt="Variedad de vapers sobre fondo azul" loading="lazy" />
-      <img src="/assets/Imagen de WhatsApp 2025-07-18 a las 01.27.53_af5c1526.jpg" alt="Detalle de pod con luces de neón" loading="lazy" />
-    </div>
-  </div>
-</section>
+  </section>
 
 
 <section class="productos-section">

--- a/styles.css
+++ b/styles.css
@@ -118,10 +118,26 @@ button {
   overflow: hidden;
 }
 
+.site-header::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.82) 0%, rgba(255, 255, 255, 0.68) 100%);
+  z-index: 1;
+  pointer-events: none;
+}
+
+.header-media {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  background: url('/assets/2023_1120_Ignite_Lifestyle_MikeKirschbaum_016_1_1000x.webp') center / cover no-repeat;
+}
+
 .header-top {
   position: sticky;
   top: 0;
-  z-index: 20;
+  z-index: 2;
   background: rgba(255, 255, 255, 0.9);
   backdrop-filter: blur(12px);
   border-bottom: 1px solid var(--color-border);
@@ -239,14 +255,7 @@ button {
   align-items: center;
   justify-content: center;
   padding: clamp(64px, 12vw, 96px) 0;
-}
-
-.header-visual::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.82) 0%, rgba(255, 255, 255, 0.68) 100%);
-  z-index: -1;
+  z-index: 2;
 }
 
 .header-video {
@@ -255,12 +264,11 @@ button {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  z-index: -2;
 }
 
 .header-visual-content {
   position: relative;
-  z-index: 1;
+  z-index: 2;
   width: 100%;
   display: flex;
   justify-content: flex-start;
@@ -300,6 +308,12 @@ button {
   gap: clamp(20px, 6vw, 40px);
   align-items: stretch;
   min-height: 54vh;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .header-media video {
+    display: none;
+  }
 }
 
 .hero-gallery-main,


### PR DESCRIPTION
## Summary
- embed the autoplay hero video inside the header background layer with explicit stacking to keep content above it
- keep the gradient overlay and hero copy intact while providing a reduced-motion fallback using the existing poster image
- position the hero gallery section immediately after the header so the imagery remains below the video hero

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddb89765a4832787beecf54c3807a1