### PR TITLE
Armoniza header y hero

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -155,9 +155,8 @@ button {
   justify-content: space-between;
   gap: var(--space-16);
   padding: var(--space-16) var(--container-padding-mobile);
-  width: 100vw;
-  max-width: 100vw;
-  margin: 0;
+  width: min(100%, var(--container-max));
+  margin: 0 auto;
 }
 
 .header-bar > *:not(.header-media) {
@@ -172,6 +171,13 @@ button {
   text-transform: uppercase;
   color: var(--color-text);
   text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.45rem 1rem;
+  border-radius: var(--radius-pill);
+  background: #fff;
+  box-shadow: 0 6px 20px rgba(15, 23, 42, 0.08);
 }
 
 .header-nav {
@@ -184,10 +190,13 @@ button {
   color: var(--color-text-secondary);
   font-size: 0.95rem;
   font-weight: 500;
-  padding: var(--space-8) 0;
+  padding: 0.5rem 1rem;
   min-height: 44px;
   display: inline-flex;
   align-items: center;
+  border-radius: var(--radius-pill);
+  background: #fff;
+  box-shadow: 0 4px 16px rgba(15, 23, 42, 0.08);
 }
 
 .header-nav a:hover,
@@ -220,6 +229,7 @@ button {
 .header-announcement {
   border-top: 1px solid var(--color-border);
   background: rgba(241, 245, 249, 0.9);
+  box-shadow: inset 0 -1px 0 rgba(148, 163, 184, 0.25);
 }
 
 .header-announcement .anuncio-carrusel {
@@ -307,27 +317,25 @@ button {
 }
 
 .hero {
-  background: var(--color-base);
-  padding: 16px 0 0 0;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.9) 0%, rgba(248, 250, 252, 0.9) 100%);
+  padding: 8px 0 0 0;
+  margin-top: -8px;
 }
 
 .hero-gallery {
-  width: 100vw;
-  max-width: 100vw;
-  margin-left: 50%;
-  transform: translateX(-50%);
+  width: min(100%, var(--container-max));
+  margin: 0 auto;
   display: flex;
   justify-content: center;
   align-items: center;
   min-height: 40vh;
-  padding: 0;
+  padding: 0 var(--container-padding-mobile);
   gap: 0;
 }
 
 .hero-gallery-main {
   position: relative;
-  width: 100vw;
-  max-width: 100vw;
+  width: 100%;
   min-height: 320px;
   display: flex;
   align-items: center;
@@ -368,9 +376,8 @@ button {
 
 .slider {
   position: relative;
-  width: 100vw;
-  max-width: 100vw;
-  height: 60vh;
+  width: 100%;
+  height: clamp(360px, 60vh, 560px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -378,8 +385,7 @@ button {
 }
 
 .slider-images {
-  width: 100vw;
-  max-width: 100vw;
+  width: 100%;
   height: 100%;
   position: relative;
   display: flex;
@@ -390,8 +396,8 @@ button {
 .slider-img {
   position: absolute;
   left: 0; top: 0;
-  width: 100vw;
-  height: 60vh;
+  width: 100%;
+  height: 100%;
   object-fit: cover;
   opacity: 0;
   transition: opacity 0.5s;
@@ -445,6 +451,9 @@ button {
   max-width: 520px;
   width: 90%;
   box-shadow: 0 8px 32px rgba(0,0,0,0.18);
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(226, 232, 240, 0.9);
+  backdrop-filter: blur(18px);
 }
 
 .hero-gallery-stack {


### PR DESCRIPTION
## Summary
- centra la barra principal del header dentro del ancho del contenedor y añade fondos blancos al logo y a los enlaces de productos/contacto para mejorar la lectura
- armoniza el estilo visual del hero con el header ajustando el fondo, el ancho del carrusel y la tarjeta de mensaje principal, además de acercar la sección al aviso superior

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e02ab8fdf8832789e7e8af7462388e