### PR TITLE
Apply dark glass aesthetic across catalog and footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,46 +16,51 @@
 
 
   <header class="site-header" id="inicio">
-    <div class="header-top">
+    <div class="header-glass">
       <div class="header-bar">
-        <div class="header-media" aria-hidden="true">
-          <video class="header-video" autoplay muted loop playsinline preload="metadata" poster="/assets/2023_1120_Ignite_Lifestyle_MikeKirschbaum_016_1_1000x.webp">
-            <source src="/assets/Ink-35508-1.mp4" type="video/mp4" />
-          </video>
-        </div>
-        <a class="header-logo" href="#inicio">VAPEZRT</a>
+        <a class="header-logo" href="#inicio" aria-label="Ir al inicio">
+          <span>VAPEZRT</span>
+        </a>
         <nav class="header-nav" aria-label="Secciones principales">
           <a href="#productos">Productos</a>
           <a href="#contacto">Contacto</a>
         </nav>
         <a class="header-cta" href="https://wa.me/5493487652952" target="_blank" rel="noopener">Comprar ahora</a>
       </div>
-      <div class="header-announcement" aria-live="polite">
-        <div class="anuncio-carrusel">
-          <div class="mensaje" id="mensaje-rotativo">📱 Seguinos en Instagram @vapezrt_</div>
-        </div>
-      </div>
     </div>
   </header>
 
-  <section class="hero" aria-labelledby="galeria-title">
-    <div class="section-container hero-gallery">
-      <div class="hero-gallery-main">
-        <div class="header-copy">
-          <span class="hero-badge">Experiencias premium</span>
-          <h1>Explorá nuestros sabores</h1>
-          <p>Los mejores pods y desechables, curados para que encuentres tu vapor ideal al instante.</p>
+  <section class="hero" aria-labelledby="hero-title">
+    <div class="hero-surface">
+      <div class="hero-media">
+        <div class="hero-slide active" data-index="0" aria-hidden="false">
+          <img src="/assets/2023_1120_Ignite_Lifestyle_MikeKirschbaum_016_1_1000x.webp" alt="Dispositivo vape color negro iluminado" />
         </div>
-        <div class="slider">
-          <button class="slider-btn slider-btn-prev" aria-label="Anterior">&lt;</button>
-          <div class="slider-images">
-            <img class="slider-img active" src="/assets/2023_1120_Ignite_Lifestyle_MikeKirschbaum_016_1_1000x.webp" alt="Dispositivo vape color negro iluminado" />
-            <img class="slider-img" src="assets/Imagen de WhatsApp 2025-07-17 a las 22.23.09_bf985f76.webp.jpg" alt="Variedad de vapers sobre fondo azul" />
-            <img class="slider-img" src="/assets/Imagen de WhatsApp 2025-07-18 a las 01.27.53_af5c1526.jpg" alt="Detalle de pod con luces de neón" />
-          </div>
-          <button class="slider-btn slider-btn-next" aria-label="Siguiente">&gt;</button>
+        <div class="hero-slide" data-index="1" aria-hidden="true">
+          <img src="assets/Imagen de WhatsApp 2025-07-17 a las 22.23.09_bf985f76.webp.jpg" alt="Variedad de vapers sobre fondo azul" loading="lazy" />
+        </div>
+        <div class="hero-slide" data-index="2" aria-hidden="true">
+          <img src="/assets/Imagen de WhatsApp 2025-07-18 a las 01.27.53_af5c1526.jpg" alt="Detalle de pod con luces de neón" loading="lazy" />
         </div>
       </div>
+      <div class="hero-inner">
+        <div class="hero-message-card">
+          <span class="hero-badge">Experiencias premium</span>
+          <h1 id="hero-title">Explorá nuestros sabores</h1>
+          <p>Los mejores pods y desechables, curados para que encuentres tu vapor ideal al instante.</p>
+          <div class="hero-actions">
+            <a class="hero-btn hero-btn-primary" href="#productos">Ver productos</a>
+            <a class="hero-btn hero-btn-secondary" href="https://wa.me/5493487652952" target="_blank" rel="noopener">Asesoramiento</a>
+          </div>
+        </div>
+      </div>
+      <button class="hero-control hero-control-prev" type="button" aria-label="Mostrar imagen anterior">
+        <span aria-hidden="true">&#8592;</span>
+      </button>
+      <button class="hero-control hero-control-next" type="button" aria-label="Mostrar imagen siguiente">
+        <span aria-hidden="true">&#8594;</span>
+      </button>
+      <div class="hero-dots" role="tablist" aria-label="Cambiar imagen del hero"></div>
     </div>
   </section>
 
@@ -67,9 +72,9 @@
       <h2>Descubrí el vapor ideal para tu estilo</h2>
       <p>Elegí entre los pods y desechables más buscados del mercado, curados para que disfrutes sabores intensos y experiencias premium en cada calada.</p>
       <div class="productos-beneficios">
-        <div class="beneficio">🚚 Envíos rápidos en toda la zona</div>
-        <div class="beneficio">💬 Asesoramiento personalizado 24/7</div>
-        <div class="beneficio">🎯 Productos 100% originales</div>
+        <div class="beneficio" tabindex="0">🚚 Envíos rápidos en toda la zona</div>
+        <div class="beneficio" tabindex="0">💬 Asesoramiento personalizado 24/7</div>
+        <div class="beneficio" tabindex="0">🎯 Productos 100% originales</div>
       </div>
     </div>
   </div>
@@ -109,9 +114,11 @@
       </div>
 
       <div class="footer-cta">
-        <h3>¿Listo para tu próximo sabor?</h3>
-        <p>Escribinos y conseguí asesoramiento en segundos. Nuestro team está online para ayudarte a elegir el pod perfecto.</p>
-        <a class="btn-wsp-outline" href="https://wa.me/5493487652952" target="_blank">Hablar por WhatsApp</a>
+        <div class="footer-cta-card">
+          <h3>¿Listo para tu próximo sabor?</h3>
+          <p>Escribinos y conseguí asesoramiento en segundos. Nuestro team está online para ayudarte a elegir el pod perfecto.</p>
+          <a class="btn-wsp-outline" href="https://wa.me/5493487652952" target="_blank" rel="noopener">Hablar por WhatsApp</a>
+        </div>
       </div>
 
       <div class="footer-contacto">
@@ -154,30 +161,159 @@
 <script src="scripts/main.js" defer></script>
 <script type="module" src="scripts/firebase.js"></script>
 <script>
-// Slider simple
-document.addEventListener('DOMContentLoaded', function() {
-  const images = document.querySelectorAll('.slider-img');
-  const prevBtn = document.querySelector('.slider-btn-prev');
-  const nextBtn = document.querySelector('.slider-btn-next');
+document.addEventListener('DOMContentLoaded', () => {
+  const slides = Array.from(document.querySelectorAll('.hero-slide'));
+  const prevBtn = document.querySelector('.hero-control-prev');
+  const nextBtn = document.querySelector('.hero-control-next');
+  const dotsContainer = document.querySelector('.hero-dots');
+  const AUTOPLAY_DELAY = 5000;
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
   let current = 0;
+  let autoplayId = null;
 
-  function showImage(idx) {
-    images.forEach((img, i) => {
-      img.classList.toggle('active', i === idx);
+  if (!slides.length) {
+    return;
+  }
+
+  const dots = [];
+
+  slides.forEach((slide, index) => {
+    slide.id = `hero-slide-${index}`;
+    slide.dataset.index = String(index);
+    slide.setAttribute('role', 'group');
+    slide.setAttribute('aria-roledescription', 'slide');
+    slide.setAttribute('aria-label', `${index + 1} de ${slides.length}`);
+    slide.setAttribute('aria-hidden', index === current ? 'false' : 'true');
+
+    if (dotsContainer) {
+      const dot = document.createElement('button');
+      dot.className = 'hero-dot';
+      dot.type = 'button';
+      dot.dataset.slide = String(index);
+      dot.setAttribute('role', 'tab');
+      dot.setAttribute('aria-controls', slide.id);
+      dot.setAttribute('aria-label', `Mostrar imagen ${index + 1} de ${slides.length}`);
+      dot.setAttribute('aria-selected', index === current ? 'true' : 'false');
+      dot.setAttribute('tabindex', index === current ? '0' : '-1');
+      dotsContainer.appendChild(dot);
+      dots.push(dot);
+    }
+  });
+
+  function goToSlide(index) {
+    current = (index + slides.length) % slides.length;
+    slides.forEach((slide, idx) => {
+      const isActive = idx === current;
+      slide.classList.toggle('active', isActive);
+      slide.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+    });
+
+    dots.forEach((dot, idx) => {
+      const isActive = idx === current;
+      dot.classList.toggle('active', isActive);
+      dot.setAttribute('aria-selected', isActive ? 'true' : 'false');
+      dot.setAttribute('tabindex', isActive ? '0' : '-1');
     });
   }
 
-  prevBtn.addEventListener('click', () => {
-    current = (current - 1 + images.length) % images.length;
-    showImage(current);
+  function showNext() {
+    goToSlide(current + 1);
+  }
+
+  function showPrev() {
+    goToSlide(current - 1);
+  }
+
+  function stopAutoplay() {
+    if (autoplayId !== null) {
+      clearInterval(autoplayId);
+      autoplayId = null;
+    }
+  }
+
+  function startAutoplay() {
+    if (prefersReducedMotion.matches || slides.length < 2) {
+      return;
+    }
+
+    stopAutoplay();
+    autoplayId = window.setInterval(showNext, AUTOPLAY_DELAY);
+  }
+
+  function restartAutoplay() {
+    stopAutoplay();
+    startAutoplay();
+  }
+
+  if (prevBtn) {
+    prevBtn.addEventListener('click', () => {
+      showPrev();
+      restartAutoplay();
+    });
+  }
+
+  if (nextBtn) {
+    nextBtn.addEventListener('click', () => {
+      showNext();
+      restartAutoplay();
+    });
+  }
+
+  dots.forEach((dot) => {
+    dot.addEventListener('click', () => {
+      const target = Number(dot.dataset.slide || 0);
+      goToSlide(target);
+      restartAutoplay();
+    });
+
+    dot.addEventListener('keydown', (event) => {
+      const key = event.key;
+      if (key === 'Enter' || key === ' ') {
+        event.preventDefault();
+        const target = Number(dot.dataset.slide || 0);
+        goToSlide(target);
+        restartAutoplay();
+      }
+
+      if (key === 'ArrowRight' || key === 'ArrowLeft') {
+        event.preventDefault();
+        const delta = key === 'ArrowRight' ? 1 : -1;
+        const currentIndex = Number(dot.dataset.slide || 0);
+        const targetIndex = (currentIndex + delta + slides.length) % slides.length;
+        const targetDot = dots[targetIndex];
+        if (targetDot) {
+          targetDot.focus();
+          goToSlide(targetIndex);
+          restartAutoplay();
+        }
+      }
+    });
   });
 
-  nextBtn.addEventListener('click', () => {
-    current = (current + 1) % images.length;
-    showImage(current);
+  const handleMotionChange = (event) => {
+    if (event.matches) {
+      stopAutoplay();
+    } else {
+      startAutoplay();
+    }
+  };
+
+  if (typeof prefersReducedMotion.addEventListener === 'function') {
+    prefersReducedMotion.addEventListener('change', handleMotionChange);
+  } else if (typeof prefersReducedMotion.addListener === 'function') {
+    prefersReducedMotion.addListener(handleMotionChange);
+  }
+
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden) {
+      stopAutoplay();
+    } else {
+      startAutoplay();
+    }
   });
 
-  showImage(current);
+  goToSlide(current);
+  startAutoplay();
 });
 </script>
 

--- a/styles.css
+++ b/styles.css
@@ -1,17 +1,18 @@
 @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap');
 
 :root {
-  --color-base: #FFFFFF;
-  --color-text: #0F172A;
-  --color-text-secondary: #475569;
-  --color-border: #E5E7EB;
-  --color-muted: #F8FAFC;
-  --color-accent: #111827;
-  --color-accent-hover: #0B1220;
-  --shadow-elev-1: 0 2px 10px rgba(0, 0, 0, 0.06);
-  --shadow-elev-2: 0 8px 30px rgba(0, 0, 0, 0.12);
-  --radius-surface: 12px;
-  --radius-modal: 16px;
+  --color-base: #030712;
+  --color-text: #e2e8f0;
+  --color-text-secondary: #a8b6d9;
+  --color-border: rgba(148, 163, 184, 0.28);
+  --color-muted: rgba(15, 23, 42, 0.6);
+  --color-accent: #f8fafc;
+  --color-accent-strong: #f9734e;
+  --color-accent-hover: #ff8c61;
+  --shadow-elev-1: 0 10px 30px rgba(0, 0, 0, 0.35);
+  --shadow-elev-2: 0 18px 45px rgba(2, 6, 23, 0.55);
+  --radius-surface: 18px;
+  --radius-modal: 20px;
   --radius-pill: 999px;
   --space-8: 8px;
   --space-12: 12px;
@@ -22,7 +23,12 @@
   --container-max: 1140px;
   --container-padding-mobile: 16px;
   --container-padding-desktop: 24px;
-  color-scheme: light;
+  --glass-surface: rgba(255, 255, 255, 0.08);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-border-strong: rgba(255, 255, 255, 0.22);
+  --glass-blur: 14px;
+  --gradient-accent: linear-gradient(135deg, #ff6b3d 0%, #ff9770 100%);
+  color-scheme: dark;
 }
 
 * {
@@ -32,11 +38,41 @@
 body {
   font-family: 'Poppins', sans-serif;
   margin: 0;
-  background: var(--color-base);
+  background-color: var(--color-base);
   color: var(--color-text);
   min-height: 100vh;
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
+  position: relative;
+  overflow-x: hidden;
+}
+
+/* Background Global */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -2;
+  background-image:
+    radial-gradient(circle at 15% 20%, rgba(48, 88, 166, 0.35), transparent 52%),
+    radial-gradient(circle at 85% 15%, rgba(123, 44, 191, 0.22), transparent 50%),
+    radial-gradient(circle at 80% 85%, rgba(15, 118, 110, 0.18), transparent 55%),
+    radial-gradient(circle at -10% 85%, rgba(15, 23, 42, 0.35), transparent 60%),
+    linear-gradient(180deg, rgba(2, 6, 23, 0.94) 0%, rgba(2, 6, 23, 0.98) 100%);
+  background-repeat: no-repeat;
+  pointer-events: none;
+}
+
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140' viewBox='0 0 140 140'%3E%3Crect width='140' height='140' fill='rgba(255,255,255,0)'/%3E%3Ccircle cx='12' cy='8' r='1.1' fill='rgba(255,255,255,0.05)'/%3E%3Ccircle cx='90' cy='30' r='0.8' fill='rgba(255,255,255,0.04)'/%3E%3Ccircle cx='40' cy='70' r='0.9' fill='rgba(255,255,255,0.05)'/%3E%3Ccircle cx='120' cy='110' r='0.7' fill='rgba(255,255,255,0.04)'/%3E%3Ccircle cx='70' cy='130' r='0.6' fill='rgba(255,255,255,0.04)'/%3E%3C/svg%3E");
+  background-size: 140px 140px;
+  mix-blend-mode: screen;
+  opacity: 0.05;
+  pointer-events: none;
 }
 
 a {
@@ -111,73 +147,56 @@ button {
   height: 56px;
 }
 
+/* Header Pro */
 .site-header {
-  position: relative;
-  background: var(--color-base);
-  color: var(--color-text);
-  overflow: hidden;
-}
-
-.site-header::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.82) 0%, rgba(255, 255, 255, 0.68) 100%);
-  z-index: 1;
-  pointer-events: none;
-}
-
-.header-media {
-  position: absolute;
-  inset: 0;
-  z-index: 0;
-  width: 100vw;
-  max-width: 100vw;
-  height: 100%;
-  pointer-events: none;
-  background: url('/assets/2023_1120_Ignite_Lifestyle_MikeKirschbaum_016_1_1000x.webp') center / cover no-repeat;
-}
-
-.header-top {
   position: sticky;
   top: 0;
-  z-index: 2;
-  background: rgba(255, 255, 255, 0.9);
-  backdrop-filter: blur(12px);
-  border-bottom: 1px solid var(--color-border);
+  z-index: 100;
+  width: 100%;
+}
+
+.header-glass {
+  position: relative;
+  width: 100%;
+  background: rgba(15, 23, 42, 0.75);
+  backdrop-filter: blur(18px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.28);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.25);
 }
 
 .header-bar {
-  position: relative;
-  z-index: 1;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--space-16);
-  padding: var(--space-16) var(--container-padding-mobile);
   width: min(100%, var(--container-max));
   margin: 0 auto;
-}
-
-.header-bar > *:not(.header-media) {
-  position: relative;
-  z-index: 1;
+  padding: 0.75rem var(--container-padding-mobile);
+  min-height: 68px;
 }
 
 .header-logo {
-  font-size: clamp(1.1rem, 2.5vw, 1.4rem);
-  font-weight: 600;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--color-text);
-  text-decoration: none;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.45rem 1rem;
+  padding: 0.55rem 1.4rem;
   border-radius: var(--radius-pill);
-  background: #fff;
-  box-shadow: 0 6px 20px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(226, 232, 240, 0.24);
+  background: rgba(15, 23, 42, 0.45);
+  color: #f8fafc;
+  font-size: clamp(1.05rem, 2vw, 1.3rem);
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  text-decoration: none;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.header-logo:hover,
+.header-logo:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(226, 232, 240, 0.5);
+  outline: none;
 }
 
 .header-nav {
@@ -187,21 +206,40 @@ button {
 }
 
 .header-nav a {
-  color: var(--color-text-secondary);
-  font-size: 0.95rem;
-  font-weight: 500;
-  padding: 0.5rem 1rem;
-  min-height: 44px;
+  position: relative;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
+  padding: 0.5rem 1.1rem;
   border-radius: var(--radius-pill);
-  background: #fff;
-  box-shadow: 0 4px 16px rgba(15, 23, 42, 0.08);
+  color: #e2e8f0;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  min-height: 44px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.header-nav a::after {
+  content: "";
+  position: absolute;
+  inset: auto 12% 0 12%;
+  height: 2px;
+  background: rgba(248, 250, 252, 0.8);
+  opacity: 0;
+  transform: translateY(6px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
 }
 
 .header-nav a:hover,
 .header-nav a:focus-visible {
-  color: var(--color-accent);
+  color: #fff;
+  text-decoration: none;
+}
+
+.header-nav a:hover::after,
+.header-nav a:focus-visible::after {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 .header-cta {
@@ -210,275 +248,327 @@ button {
   justify-content: center;
   padding: 0.75rem 1.6rem;
   border-radius: var(--radius-pill);
-  border: 1px solid var(--color-accent);
-  background: var(--color-accent);
-  color: #fff;
+  background: linear-gradient(135deg, #f97316 0%, #fb7185 100%);
+  color: #0f172a;
   font-weight: 600;
   min-height: 44px;
-  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+  border: 1px solid rgba(249, 115, 22, 0.4);
+  box-shadow: 0 12px 24px rgba(249, 115, 22, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
 }
 
 .header-cta:hover,
 .header-cta:focus-visible {
-  background: var(--color-accent-hover);
-  border-color: var(--color-accent-hover);
-  transform: translateY(-1px);
+  transform: translateY(-2px);
+  box-shadow: 0 16px 32px rgba(249, 115, 22, 0.35);
   text-decoration: none;
+  filter: brightness(1.05);
 }
 
-.header-announcement {
-  border-top: 1px solid var(--color-border);
-  background: rgba(241, 245, 249, 0.9);
-  box-shadow: inset 0 -1px 0 rgba(148, 163, 184, 0.25);
-}
-
-.header-announcement .anuncio-carrusel {
-  padding: 8px var(--container-padding-mobile);
-  width: min(100%, var(--container-max));
-  margin: 0 auto;
-}
-
-.anuncio-carrusel {
-  position: relative;
-  overflow: hidden;
-  width: 100%;
-  height: 1.5em;
-}
-
-.mensaje {
-  position: absolute;
-  white-space: nowrap;
-  color: var(--color-text-secondary);
-  font-size: 0.9rem;
-  animation: slide 16s linear infinite;
-}
-
-@keyframes slide {
-  0% {
-    left: 100%;
+@media (max-width: 767px) {
+  .header-nav {
+    display: none;
   }
-  100% {
-    left: -100%;
+
+  .header-bar {
+    padding-inline: var(--container-padding-mobile);
   }
-}
-
-
-.header-visual {
-  position: relative;
-  isolation: isolate;
-  min-height: 46vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: clamp(64px, 12vw, 96px) 0;
-  z-index: 2;
-}
-
-.header-video {
-  position: absolute;
-  inset: 0;
-  width: 100vw;
-  max-width: 100vw;
-  height: 100%;
-  object-fit: cover;
-  z-index: 0;
-  pointer-events: none;
-}
-
-.header-visual-content {
-  position: relative;
-  z-index: 2;
-  width: 100%;
-  display: flex;
-  justify-content: flex-start;
-}
-
-.header-copy {
-  max-width: 520px;
-  padding: clamp(24px, 5vw, 40px);
-  border-radius: var(--radius-surface);
-  border: 1px solid rgba(229, 231, 235, 0.8);
-  background: rgba(255, 255, 255, 0.9);
-  box-shadow: var(--shadow-elev-2);
-}
-
-.header-copy h1 {
-  font-size: clamp(2.4rem, 5vw, 3.4rem);
-  margin: 0 0 var(--space-16);
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  color: var(--color-text);
-}
-
-.header-copy p {
-  margin: 0;
-  color: var(--color-text-secondary);
-  line-height: 1.6;
-}
-
-.hero {
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.9) 0%, rgba(248, 250, 252, 0.9) 100%);
-  padding: 8px 0 0 0;
-  margin-top: -8px;
-}
-
-.hero-gallery {
-  width: min(100%, var(--container-max));
-  margin: 0 auto;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  min-height: 40vh;
-  padding: 0 var(--container-padding-mobile);
-  gap: 0;
-}
-
-.hero-gallery-main {
-  position: relative;
-  width: 100%;
-  min-height: 320px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: var(--radius-surface);
-  overflow: hidden;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .header-media video {
-    display: none;
+  .header-logo,
+  .header-nav a,
+  .header-cta {
+    transition-duration: 0.01ms;
+    transition-delay: 0s;
   }
 }
 
-.hero-gallery-main,
-.hero-gallery-stack {
+/* Hero Pro */
+.hero {
   position: relative;
-  border-radius: var(--radius-surface);
+  width: 100%;
+  margin: 0;
+  color: #f8fafc;
+  background: #020617;
+}
+
+.hero-surface {
+  position: relative;
+  min-height: 72vh;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(96px, 18vh, 160px) var(--container-padding-mobile) clamp(80px, 16vh, 140px);
   overflow: hidden;
+  isolation: isolate;
 }
 
-.hero-gallery-main {
-  position: relative;
-  box-shadow: var(--shadow-elev-2);
-  background: var(--color-muted);
-  min-height: 320px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.hero-gallery-main img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  border-radius: var(--radius-surface);
-}
-
-.slider {
-  position: relative;
-  width: 100%;
-  height: clamp(360px, 60vh, 560px);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden;
-}
-
-.slider-images {
-  width: 100%;
-  height: 100%;
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.slider-img {
+.hero-surface::before {
+  content: "";
   position: absolute;
-  left: 0; top: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  opacity: 0;
-  transition: opacity 0.5s;
-  border-radius: var(--radius-surface);
-  z-index: 1;
+  inset: 0;
+  background: radial-gradient(circle at center, rgba(2, 6, 23, 0) 0%, rgba(2, 6, 23, 0.78) 100%);
+  z-index: 2;
   pointer-events: none;
 }
 
-.slider-img.active {
-  opacity: 1;
+.hero-surface::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.55) 0%, rgba(15, 23, 42, 0.5) 45%, rgba(2, 6, 23, 0.85) 100%);
   z-index: 2;
-  pointer-events: auto;
+  pointer-events: none;
 }
 
-.slider-btn {
+.hero-media {
   position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  background: rgba(255,255,255,0.7);
-  border: none;
-  border-radius: var(--radius-pill);
-  font-size: 2rem;
-  color: var(--color-accent);
-  padding: 0.5em 1em;
-  cursor: pointer;
-  z-index: 10;
-  box-shadow: var(--shadow-elev-1);
-  transition: background 0.2s;
+  pointer-events: none;
+  inset: 0;
+  overflow: hidden;
+  z-index: 1;
 }
 
-.slider-btn:hover,
-.slider-btn:focus-visible {
-  background: var(--color-accent);
-  color: #fff;
-}
-
-.slider-btn-prev {
-  left: 16px;
-}
-
-.slider-btn-next {
-  right: 16px;
-}
-
-.hero-gallery-main .header-copy {
+.hero-slide {
   position: absolute;
-  z-index: 20;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  max-width: 520px;
-  width: 90%;
-  box-shadow: 0 8px 32px rgba(0,0,0,0.18);
-  background: rgba(255, 255, 255, 0.92);
-  border: 1px solid rgba(226, 232, 240, 0.9);
-  backdrop-filter: blur(18px);
+  inset: 0;
+  opacity: 0;
+  transition: opacity 1.1s ease;
 }
 
-.hero-gallery-stack {
-  display: grid;
-  gap: clamp(16px, 4vw, 24px);
-  grid-auto-rows: 1fr;
-  min-height: 320px;
+.hero-slide.active {
+  opacity: 1;
 }
 
-.hero-gallery-stack img {
+.hero-slide img {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  border-radius: var(--radius-surface);
-  border: 1px solid var(--color-border);
-  box-shadow: var(--shadow-elev-1);
-  background: var(--color-base);
-  aspect-ratio: 4 / 5;
+  display: block;
+}
+
+.hero-inner {
+  position: relative;
+  z-index: 3;
+  width: min(100%, var(--container-max));
+  margin: 0 auto;
+  display: flex;
+  justify-content: center;
+}
+
+.hero-message-card {
+  max-width: 520px;
+  width: min(100%, 520px);
+  padding: clamp(24px, 4vw, 48px);
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(18px);
+  box-shadow: 0 28px 60px rgba(2, 6, 23, 0.45);
+}
+
+.hero-message-card h1 {
+  font-size: clamp(2.4rem, 6vw, 3.6rem);
+  margin: 0 0 var(--space-16);
+  letter-spacing: -0.01em;
+  font-weight: 600;
+}
+
+.hero-message-card p {
+  margin: 0 0 var(--space-24);
+  color: rgba(226, 232, 240, 0.88);
+  line-height: 1.7;
+}
+
+.hero .hero-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 6px 16px;
+  border-radius: var(--radius-pill);
+  background: rgba(148, 163, 184, 0.2);
+  color: #f8fafc;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  font-weight: 600;
+  margin-bottom: var(--space-16);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-12);
+}
+
+.hero-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  padding: 0.75rem 1.6rem;
+  border-radius: var(--radius-pill);
+  font-weight: 600;
+  font-size: 0.98rem;
+  letter-spacing: 0.02em;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.hero-btn-primary {
+  background: linear-gradient(135deg, #f97316 0%, #fb7185 100%);
+  color: #0f172a;
+  border-color: rgba(249, 115, 22, 0.5);
+  box-shadow: 0 18px 36px rgba(249, 115, 22, 0.35);
+}
+
+.hero-btn-primary:hover,
+.hero-btn-primary:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 48px rgba(249, 115, 22, 0.45);
+  text-decoration: none;
+}
+
+.hero-btn-secondary {
+  background: rgba(15, 23, 42, 0.35);
+  color: #f8fafc;
+  border-color: rgba(148, 163, 184, 0.4);
+  box-shadow: 0 10px 24px rgba(2, 6, 23, 0.35);
+}
+
+.hero-btn-secondary:hover,
+.hero-btn-secondary:focus-visible {
+  background: rgba(15, 23, 42, 0.55);
+  text-decoration: none;
+  transform: translateY(-2px);
+}
+
+.hero-btn:focus-visible {
+  outline: 2px solid rgba(248, 250, 252, 0.9);
+  outline-offset: 2px;
+}
+
+.hero-control {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: rgba(15, 23, 42, 0.55);
+  color: #f8fafc;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 4;
+  box-shadow: 0 12px 32px rgba(2, 6, 23, 0.45);
+  backdrop-filter: blur(12px);
+  transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+}
+
+.hero-control:hover,
+.hero-control:focus-visible {
+  transform: translateY(-50%) translateY(-2px);
+  background: rgba(15, 23, 42, 0.75);
+  border-color: rgba(148, 163, 184, 0.7);
+}
+
+.hero-control-prev {
+  left: clamp(16px, 4vw, 40px);
+}
+
+.hero-control-next {
+  right: clamp(16px, 4vw, 40px);
+}
+
+.hero-dots {
+  position: absolute;
+  bottom: clamp(24px, 6vh, 48px);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  z-index: 4;
+}
+
+.hero-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(248, 250, 252, 0.55);
+  background: rgba(248, 250, 252, 0.24);
+  padding: 0;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.hero-dot.active {
+  transform: scale(1.35);
+  background: #f8fafc;
+}
+
+.hero-dot:focus-visible {
+  outline: 2px solid rgba(248, 250, 252, 0.9);
+  outline-offset: 2px;
+}
+
+@media (max-width: 767px) {
+  .hero-surface {
+    min-height: 65vh;
+    padding: clamp(88px, 20vh, 132px) var(--container-padding-mobile) clamp(68px, 18vh, 112px);
+  }
+
+  .hero-inner {
+    justify-content: center;
+  }
+
+  .hero-message-card {
+    padding: clamp(24px, 8vw, 40px);
+    text-align: center;
+  }
+
+  .hero-actions {
+    justify-content: center;
+  }
+
+  .hero-control {
+    width: 44px;
+    height: 44px;
+  }
+
+  .hero-control-prev {
+    left: 12px;
+  }
+
+  .hero-control-next {
+    right: 12px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-slide {
+    transition-duration: 0.01ms;
+    transition-delay: 0s;
+  }
+
+  .hero-btn,
+  .hero-control,
+  .hero-dot {
+    transition: none;
+  }
 }
 
 .hero-card {
-  background: rgba(255, 255, 255, 0.95);
+  background: rgba(15, 23, 42, 0.58);
   border-radius: var(--radius-surface);
-  border: 1px solid var(--color-border);
-  box-shadow: var(--shadow-elev-2);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--shadow-elev-1);
+  backdrop-filter: blur(var(--glass-blur));
   padding: clamp(24px, 5vw, 40px);
   max-width: 560px;
   margin: 0 auto;
@@ -505,13 +595,14 @@ button {
   gap: 0.35rem;
   padding: 6px 16px;
   border-radius: var(--radius-pill);
-  background: rgba(17, 24, 39, 0.08);
-  color: var(--color-accent);
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--color-text);
   text-transform: uppercase;
   font-size: 0.75rem;
   letter-spacing: 0.12em;
   margin-bottom: var(--space-16);
   font-weight: 600;
+  border: 1px solid rgba(255, 255, 255, 0.12);
 }
 
 .hero-busqueda {
@@ -522,11 +613,12 @@ button {
   width: 100%;
   padding: 0.85rem 1.2rem;
   border-radius: var(--radius-pill);
-  border: 1px solid var(--color-border);
-  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid var(--glass-border);
+  background: rgba(15, 23, 42, 0.65);
+  backdrop-filter: blur(var(--glass-blur));
   color: var(--color-text);
   font-size: 1rem;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
 .hero-busqueda input::placeholder {
@@ -536,22 +628,21 @@ button {
 
 .hero-busqueda input:focus {
   outline: none;
-  border-color: var(--color-accent);
-  box-shadow: 0 0 0 4px rgba(17, 24, 39, 0.12);
+  border-color: var(--glass-border-strong);
+  box-shadow: 0 0 0 3px rgba(255, 151, 112, 0.25);
+  background: rgba(15, 23, 42, 0.75);
 }
 
+/* Productos (glass cards) */
 .productos-section {
   padding: clamp(64px, 12vw, 96px) 0;
-  background: var(--color-base);
 }
 
 .busqueda-section {
-  background: var(--color-base);
   padding: clamp(16px, 5vw, 32px) 0 clamp(56px, 10vw, 88px);
 }
 
 .productos-grid-section {
-  background: var(--color-base);
   padding: clamp(16px, 5vw, 32px) 0 clamp(80px, 12vw, 120px);
 }
 
@@ -580,13 +671,15 @@ button {
   align-items: center;
   padding: 6px 18px;
   border-radius: var(--radius-pill);
-  background: rgba(17, 24, 39, 0.08);
-  color: var(--color-accent);
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--color-text);
   font-weight: 600;
   font-size: 0.78rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   margin-bottom: var(--space-16);
+  backdrop-filter: blur(calc(var(--glass-blur) - 4px));
+  border: 1px solid rgba(255, 255, 255, 0.12);
 }
 
 .productos-beneficios {
@@ -594,39 +687,53 @@ button {
   flex-wrap: wrap;
   justify-content: center;
   gap: var(--space-12);
+  margin-top: var(--space-24);
 }
 
 .beneficio {
-  background: var(--color-muted);
-  border: 1px solid var(--color-border);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid var(--glass-border);
   border-radius: var(--radius-pill);
-  padding: 10px 18px;
+  padding: 10px 20px;
   font-size: 0.95rem;
   color: var(--color-text-secondary);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: var(--shadow-elev-1);
+  backdrop-filter: blur(var(--glass-blur));
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
 }
 
 .beneficio:hover,
 .beneficio:focus-visible {
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-elev-1);
+  transform: translateY(-3px);
+  box-shadow: 0 16px 40px rgba(8, 13, 35, 0.45);
+  border-color: var(--glass-border-strong);
+  color: var(--color-text);
+}
+
+.beneficio:focus-visible {
+  outline: 2px solid rgba(255, 151, 112, 0.6);
+  outline-offset: 2px;
 }
 
 .productos {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 24px;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: clamp(20px, 4vw, 28px);
 }
 
 .producto {
   position: relative;
   border-radius: var(--radius-surface);
   padding: var(--space-24);
-  background: #fff;
-  border: 1px solid var(--color-border);
+  background: rgba(15, 23, 42, 0.58);
+  border: 1px solid var(--glass-border);
   color: var(--color-text);
   box-shadow: var(--shadow-elev-1);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  backdrop-filter: blur(var(--glass-blur));
+  transition: transform 0.35s ease, box-shadow 0.35s ease, border-color 0.35s ease;
   display: flex;
   flex-direction: column;
   gap: var(--space-16);
@@ -634,37 +741,175 @@ button {
 
 .producto:hover,
 .producto:focus-within {
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-elev-2);
+  transform: translateY(-4px);
+  box-shadow: 0 26px 50px rgba(4, 9, 26, 0.55);
+  border-color: var(--glass-border-strong);
+}
+
+.producto-media {
+  position: relative;
+  border-radius: calc(var(--radius-surface) - 6px);
+  overflow: hidden;
+  background: rgba(15, 23, 42, 0.72);
+  cursor: pointer;
 }
 
 .producto img {
   width: 100%;
   aspect-ratio: 1 / 1;
   object-fit: cover;
-  border-radius: var(--radius-surface);
-  background: var(--color-muted);
+  transition: transform 0.6s ease;
+  will-change: transform;
+}
+
+.producto:hover img,
+.producto:focus-within img {
+  transform: scale(1.03) translateY(-2px);
+}
+
+.producto-badge {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  padding: 6px 14px;
+  border-radius: var(--radius-pill);
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--color-text);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  backdrop-filter: blur(calc(var(--glass-blur) - 4px));
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.producto-media:focus-visible {
+  outline: 2px solid rgba(255, 151, 112, 0.65);
+  outline-offset: 3px;
+}
+
+.producto-info {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .producto h3 {
-  font-size: 1.05rem;
+  font-size: 1.08rem;
   margin: 0;
   font-weight: 600;
   color: var(--color-text);
 }
 
-.producto p {
+.producto-sabor {
   font-size: 0.98rem;
   margin: 0;
   color: var(--color-text-secondary);
-  font-weight: 500;
 }
 
+.producto-precio {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 4px 0 0;
+  color: var(--color-accent);
+}
+
+.producto-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: auto;
+}
+
+.producto-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.7rem 1.4rem;
+  border-radius: var(--radius-pill);
+  font-weight: 600;
+  font-size: 0.95rem;
+  border: 1px solid transparent;
+  cursor: pointer;
+  min-height: 44px;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease, background 0.25s ease, color 0.25s ease;
+  text-decoration: none;
+}
+
+.producto-btn-primary {
+  background: var(--gradient-accent);
+  color: #0b1220;
+  border-color: rgba(255, 255, 255, 0.06);
+  box-shadow: 0 12px 26px rgba(255, 129, 87, 0.35);
+}
+
+.producto-btn-primary:hover,
+.producto-btn-primary:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 38px rgba(255, 151, 112, 0.5);
+  text-decoration: none;
+}
+
+.producto-btn-secondary {
+  background: rgba(15, 23, 42, 0.55);
+  border-color: var(--glass-border);
+  color: var(--color-text-secondary);
+  backdrop-filter: blur(calc(var(--glass-blur) - 2px));
+}
+
+.producto-btn-secondary:hover,
+.producto-btn-secondary:focus-visible {
+  transform: translateY(-2px);
+  border-color: var(--glass-border-strong);
+  color: var(--color-text);
+}
+
+.producto-btn:focus-visible {
+  outline: 2px solid rgba(255, 151, 112, 0.6);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .beneficio,
+  .producto,
+  .producto-btn,
+  .producto img {
+    transition: none;
+  }
+
+  .producto:hover,
+  .producto:focus-within,
+  .beneficio:hover,
+  .beneficio:focus-visible,
+  .producto-btn-primary:hover,
+  .producto-btn-secondary:hover {
+    transform: none;
+    box-shadow: var(--shadow-elev-1);
+  }
+
+  .producto img {
+    transform: none !important;
+  }
+}
+
+/* Footer (dark glass) */
 .footer {
-  background: var(--color-base);
   color: var(--color-text);
   padding: clamp(56px, 10vw, 80px) 0 clamp(32px, 6vw, 48px);
-  border-top: 1px solid var(--color-border);
+  position: relative;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.footer::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    radial-gradient(circle at 20% 0%, rgba(69, 96, 170, 0.18), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(255, 105, 97, 0.18), transparent 52%),
+    linear-gradient(180deg, rgba(2, 6, 23, 0.92) 0%, rgba(2, 6, 23, 0.98) 100%);
+  pointer-events: none;
+  z-index: 0;
 }
 
 .footer-contenido {
@@ -674,31 +919,48 @@ button {
 
 .footer-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: var(--space-24);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: clamp(24px, 5vw, 40px);
   align-items: start;
 }
 
 .footer-brand h2 {
   font-size: 1.8rem;
   margin-bottom: var(--space-12);
+  letter-spacing: 0.18em;
 }
 
 .footer-brand p {
   margin: 0;
   color: var(--color-text-secondary);
-  line-height: 1.6;
+  line-height: 1.7;
 }
 
-.footer-cta h3,
-.footer-contacto h3 {
-  font-size: 1.15rem;
-  margin-bottom: var(--space-12);
-  font-weight: 600;
+.footer-cta {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-16);
 }
 
-.footer-cta p {
-  margin-bottom: var(--space-16);
+.footer-cta-card {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-surface);
+  padding: var(--space-24);
+  box-shadow: var(--shadow-elev-1);
+  backdrop-filter: blur(var(--glass-blur));
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-16);
+}
+
+.footer-cta-card h3 {
+  font-size: 1.3rem;
+  margin: 0;
+}
+
+.footer-cta-card p {
+  margin: 0;
   color: var(--color-text-secondary);
   line-height: 1.6;
 }
@@ -708,23 +970,29 @@ button {
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
-  background: transparent;
-  color: var(--color-accent);
-  border: 1px solid var(--color-accent);
-  padding: 0.75rem 1.6rem;
+  background: var(--gradient-accent);
+  color: #0b1220;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  padding: 0.85rem 1.8rem;
   border-radius: var(--radius-pill);
   font-weight: 600;
-  min-height: 44px;
+  min-height: 46px;
   text-decoration: none;
-  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  box-shadow: 0 16px 36px rgba(255, 129, 87, 0.35);
 }
 
 .btn-wsp-outline:hover,
 .btn-wsp-outline:focus-visible {
-  background: var(--color-accent);
-  color: #fff;
-  transform: translateY(-1px);
+  transform: translateY(-2px);
+  box-shadow: 0 22px 46px rgba(255, 151, 112, 0.45);
   text-decoration: none;
+}
+
+.footer-contacto h3 {
+  font-size: 1.15rem;
+  margin-bottom: var(--space-16);
+  font-weight: 600;
 }
 
 .footer-contacto ul {
@@ -732,26 +1000,31 @@ button {
   padding: 0;
   margin: 0;
   display: grid;
-  gap: var(--space-12);
+  gap: var(--space-16);
 }
 
 .footer-contacto li {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
+  background: rgba(15, 23, 42, 0.48);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: calc(var(--radius-surface) - 6px);
+  padding: 16px;
+  backdrop-filter: blur(calc(var(--glass-blur) - 4px));
 }
 
 .footer-contacto span {
-  font-size: 0.85rem;
+  font-size: 0.78rem;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--color-text-secondary);
+  letter-spacing: 0.12em;
+  color: rgba(226, 232, 240, 0.7);
 }
 
 .footer-contacto a {
   color: var(--color-accent);
   text-decoration: none;
-  font-weight: 500;
+  font-weight: 600;
 }
 
 .footer-contacto a:hover,
@@ -766,11 +1039,11 @@ button {
 }
 
 .footer-copy {
-  margin-top: var(--space-40);
-  font-size: 0.9rem;
-  color: var(--color-text-secondary);
+  margin-top: clamp(32px, 6vw, 48px);
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.75);
   text-align: center;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.08em;
 }
 
 .modal {
@@ -791,13 +1064,14 @@ button {
 }
 
 .modal-content {
-  background: #fff;
+  background: rgba(15, 23, 42, 0.78);
   padding: clamp(24px, 5vw, 40px);
   border-radius: var(--radius-modal);
   width: min(90%, 720px);
   position: relative;
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--glass-border);
   box-shadow: var(--shadow-elev-2);
+  backdrop-filter: blur(calc(var(--glass-blur) + 2px));
   display: grid;
   gap: var(--space-24);
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
@@ -828,7 +1102,7 @@ button {
 .modal-close:hover,
 .modal-close:focus-visible {
   color: var(--color-accent);
-  background: rgba(15, 23, 42, 0.08);
+  background: rgba(148, 163, 184, 0.18);
   outline: none;
 }
 
@@ -858,37 +1132,42 @@ button {
   justify-content: center;
   padding: 0.85rem 1.8rem;
   border-radius: var(--radius-pill);
-  background: var(--color-accent);
-  color: #fff;
+  background: var(--gradient-accent);
+  color: #0b1220;
   font-weight: 600;
-  border: 1px solid var(--color-accent);
+  border: 1px solid rgba(255, 255, 255, 0.12);
   min-height: 44px;
-  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
   text-decoration: none;
+  box-shadow: 0 16px 36px rgba(255, 129, 87, 0.35);
 }
 
 .modal-action-primary:hover,
 .modal-action-primary:focus-visible {
-  background: var(--color-accent-hover);
-  border-color: var(--color-accent-hover);
-  transform: translateY(-1px);
+  transform: translateY(-2px);
+  box-shadow: 0 24px 46px rgba(255, 151, 112, 0.45);
   text-decoration: none;
 }
 
 .modal-action-secondary {
-  background: transparent;
-  border: none;
-  color: var(--color-accent);
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid var(--glass-border);
+  color: var(--color-text-secondary);
   font-weight: 600;
   cursor: pointer;
   padding: var(--space-8) var(--space-12);
   border-radius: var(--radius-pill);
   min-height: 44px;
+  backdrop-filter: blur(calc(var(--glass-blur) - 2px));
+  transition: transform 0.25s ease, border-color 0.25s ease, color 0.25s ease;
 }
 
 .modal-action-secondary:hover,
 .modal-action-secondary:focus-visible {
-  background: rgba(15, 23, 42, 0.08);
+  background: rgba(15, 23, 42, 0.68);
+  border-color: var(--glass-border-strong);
+  color: var(--color-text);
+  transform: translateY(-2px);
   outline: none;
 }
 


### PR DESCRIPTION
## Summary
- replace the base page background with layered gradients and subtle grain to match the neon glass header and hero
- restyle the product grid into translucent glass cards with badges, price support, and dual CTAs plus prefers-reduced-motion handling
- rebuild the footer layout with a glass WhatsApp card, accented buttons, and contact chips that mirror the premium palette

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e03c64463c83278be07fd63af2d98d